### PR TITLE
Use io-ts-reporter for better error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "prebuild": "rm -rf dist/"
   },
   "dependencies": {
-    "express-promise-router": "^3.0.3"
+    "express-promise-router": "^3.0.3",
+    "io-ts-reporters": "^1.2.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as t from "io-ts";
 import { PathParams, RequestHandlerParams } from "express-serve-static-core"; // eslint-disable-line import/no-unresolved, import/extensions
-import { PathReporter } from "io-ts/lib/PathReporter";
+import reporter from 'io-ts-reporters';
 import {
   Router,
   NextFunction,
@@ -23,7 +23,7 @@ export class IoTsValidationError extends Error {
 
 type Omit<O, K> = Pick<O, Exclude<keyof O, K>>;
 
-enum MissingValidator {}
+enum MissingValidator { }
 type MissingValidatorC = t.Type<MissingValidator>;
 
 type AddBody<V> = V extends MissingValidator ? {} : { body: V };
@@ -42,11 +42,11 @@ export type ValidatedRequestHandler<
   Body = MissingValidator,
   Params = MissingValidator,
   Query = MissingValidator
-> = (
-  req: ValidatedRequest<Body, Params, Query>,
-  res: Response,
-  next: NextFunction
-) => any;
+  > = (
+    req: ValidatedRequest<Body, Params, Query>,
+    res: Response,
+    next: NextFunction
+  ) => any;
 
 interface ValidationRouterMatcher {
   (path: PathParams, ...handlers: ValidatedRequestHandler[]): void;
@@ -55,7 +55,7 @@ interface ValidationRouterMatcher {
     B extends t.Type<any, any, any> = MissingValidatorC,
     P extends t.Type<any, any, any> = MissingValidatorC,
     Q extends t.Type<any, any, any> = MissingValidatorC
-  >(
+    >(
     path: PathParams,
     validation: {
       body?: B;
@@ -86,7 +86,7 @@ function validationRoute<
       // TODO: params are always strings, so auto convert t.number to NumberFromString
       const result = reqType.params.decode(req.params);
       if (result.isLeft()) {
-        const report = PathReporter.report(result);
+        const report = reporter.report(result);
         throw new IoTsValidationError(report.join());
       }
       req.params = result.value;
@@ -95,7 +95,7 @@ function validationRoute<
       const result = reqType.query.decode(req.query);
       if (result.isLeft()) {
         // TODO: figure out which reporter we wanna use
-        const report = PathReporter.report(result);
+        const report = reporter.report(result);
         throw new IoTsValidationError(report.join());
       }
       req.query = result.value;
@@ -104,7 +104,7 @@ function validationRoute<
       const result = reqType.body.decode(req.body);
       if (result.isLeft()) {
         // TODO: figure out which reporter we wanna use
-        const report = PathReporter.report(result);
+        const report = reporter.report(result);
         throw new IoTsValidationError(report.join());
       }
       req.body = result.value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,6 @@ function validationRoute<
     if (reqType.query) {
       const result = reqType.query.decode(req.query);
       if (result.isLeft()) {
-        // TODO: figure out which reporter we wanna use
         const report = reporter.report(result);
         throw new IoTsValidationError(report.join());
       }
@@ -103,7 +102,6 @@ function validationRoute<
     if (reqType.body) {
       const result = reqType.body.decode(req.body);
       if (result.isLeft()) {
-        // TODO: figure out which reporter we wanna use
         const report = reporter.report(result);
         throw new IoTsValidationError(report.join());
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,6 +246,11 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
+io-ts-reporters@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/io-ts-reporters/-/io-ts-reporters-1.2.2.tgz#4d3219777ea5219c7d8f6ffac01fd68e72426dd1"
+  integrity sha512-igASwWWkDY757OutNcM6zTtdJf/eTZYkoe2ymsX2qpm5bKZLo74FJYjsCtMQOEdY7dRHLLEulCyFQwdN69GBCg==
+
 io-ts-types@^0.4.7:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/io-ts-types/-/io-ts-types-0.4.7.tgz#f6280da7432d6dae593d8ff064837f51bd4b96ba"


### PR DESCRIPTION
io-ts has terrible messaging that make you want to ignore the whole message. The reporter in `io-ts-reporter` seems to have a cleaner, more readable message that we can use.